### PR TITLE
fixed batch_size option processing only first batch

### DIFF
--- a/lib/strategy/base.rb
+++ b/lib/strategy/base.rb
@@ -76,14 +76,16 @@ module DataAnon
 
       def dest_table
         return @dest_table unless @dest_table.nil?
-        DataAnon::Utils::DestinationDatabase.establish_connection @destination_database if @destination_database
-        @dest_table = Utils::DestinationTable.create @name, @primary_keys
+        table_klass = Utils::DestinationTable.create @name, @primary_keys
+        table_klass.establish_connection @destination_database if @destination_database
+        @dest_table = table_klass
       end
 
       def source_table
         return @source_table unless @source_table.nil?
-        DataAnon::Utils::SourceDatabase.establish_connection @source_database
-        @source_table = Utils::SourceTable.create @name, @primary_keys
+        table_klass = Utils::SourceTable.create @name, @primary_keys
+        table_klass.establish_connection @source_database
+        @source_table = table_klass
       end
 
       def process

--- a/lib/utils/database.rb
+++ b/lib/utils/database.rb
@@ -30,14 +30,17 @@ module DataAnon
     class BaseTable
 
       def self.create_table  database, table_name, primary_keys = []
-        Class.new(database) do
-          self.table_name = table_name
-          self.primary_keys = primary_keys if primary_keys.length > 1
-          self.primary_key = primary_keys[0] if primary_keys.length == 1
-          self.primary_key = nil if primary_keys.length == 0
-          self.inheritance_column = :_type_disabled
-          self.mass_assignment_sanitizer = MassAssignmentIgnoreSanitizer.new
-        end
+        klass_name = table_name.to_s.downcase.capitalize
+        return database.const_get klass_name if database.const_defined? klass_name
+        database.const_set(klass_name, Class.new(database) do
+            self.table_name = table_name
+            self.primary_keys = primary_keys if primary_keys.length > 1
+            self.primary_key = primary_keys[0] if primary_keys.length == 1
+            self.primary_key = nil if primary_keys.length == 0
+            self.inheritance_column = :_type_disabled
+            self.mass_assignment_sanitizer = MassAssignmentIgnoreSanitizer.new
+          end
+        )
       end
 
     end

--- a/spec/acceptance/rdbms_whitelist_spec.rb
+++ b/spec/acceptance/rdbms_whitelist_spec.rb
@@ -53,6 +53,29 @@ describe 'End 2 End RDBMS Whitelist Acceptance Test using SQLite database' do
     new_rec.updated_at.should == Time.new(2010,5,5)
   end
 
+  describe 'batch_size' do
+    it 'processes all records in batches' do
+      database 'Customer' do
+        strategy DataAnon::Strategy::Whitelist
+        source_db source_connection_spec
+        destination_db dest_connection_spec
+
+        table 'customers' do
+          batch_size 1
+          whitelist 'first_name'
+        end
+      end
+
+      DataAnon::Utils::DestinationDatabase.establish_connection dest_connection_spec
+      dest_table = DataAnon::Utils::DestinationTable.create 'customers'
+      dest_table.count.should == 2
+      first_rec = dest_table.first
+      first_rec.first_name.should eq('Sunit')
+      second_rec = dest_table.second
+      second_rec.first_name.should eq('Rohit')
+    end
+  end
+
   describe 'limiting' do
     it 'returns only last record' do
       database 'Customer' do


### PR DESCRIPTION
fixes #30

Longwinded explanation:

There was some trouble with connecting to different databases through e.g.

```ruby
DataAnon::Utils::SourceDatabase.establish_connection @source_database
```

and

```ruby
DataAnon::Utils::DestinationDatabase.establish_connection @destination_database
```

In particular

the call to `DataAnon::Utils::DestinationDatabase.establish_connection` triggered by e.g.
`dest_record = dest_table.new dest_record_map, without_protection: true` in `#process_record` of the `Strategy` during processing the first batch caused the break-condition in `find_in_batches` of `ActiveRecord` to well *break* the loop and thus only the first batch would be processed.

To use different connection `ActiveRecord` likes to have *named* subclasses, which is why I created them in `BaseTable.create_table`.

Long story short: Fun debugging => it works :)