### PR TITLE
closing connections 

### DIFF
--- a/lib/strategy/base.rb
+++ b/lib/strategy/base.rb
@@ -100,6 +100,7 @@ module DataAnon
           end
           progress.close
         end
+	source_table.clear_all_connections!
       end
 
       def process_table progress


### PR DESCRIPTION
In our weekly obfuscation process we have more than 432 tables but total number of connections allocated were 256 for the postgres. This caused the script to fail after 256 connections expired and stopped the obfuscation process because connections were not closed as evident from pg_stat_activity table.

Solutions :
1) Initially to overcome this problem we split the ruby script into two parts with equal number of tables and avoided the problem .
Cons: But requires us to manage to ruby scripts for white listing whenever requirement changes.

2) Closing connections after anonymization on table, to solve the problem if there are more tables than number of connections in the ruby script. This is the proposed solution in this pull request.

