### PR TITLE
Use update_columns instead of save! for performance

### DIFF
--- a/lib/strategy/blacklist.rb
+++ b/lib/strategy/blacklist.rb
@@ -3,15 +3,16 @@ module DataAnon
     class Blacklist < DataAnon::Strategy::Base
 
       def process_record index, record
+        updates = {}
         @fields.each do |field, strategy|
           database_field_name = record.attributes.select { |k,v| k == field }.keys[0]
           field_value = record.attributes[database_field_name]
           unless field_value.nil? || is_primary_key?(database_field_name)
             field = DataAnon::Core::Field.new(database_field_name, field_value, index, record, @name)
-            record[database_field_name] = strategy.anonymize(field)
+            updates[database_field_name] = strategy.anonymize(field)
           end
         end
-        record.save!
+        record.update_columns(updates) if updates.any?
       end
 
     end


### PR DESCRIPTION
`update_columns` skips callbacks, validations, and transactions. It ["is the fastest way to update attributes"](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-update_columns).

On a local postgres table with 40000 rows, batch size 1000, anonymizing a single email field.

Before changes: 2m 52s
After changes: 1m 32s (46% faster!)