### PR TITLE
Run largest tables first when running in parallel

### DIFF
--- a/lib/parallel/table.rb
+++ b/lib/parallel/table.rb
@@ -5,7 +5,7 @@ module DataAnon
     class Table
 
       def anonymize tables
-        ::Parallel.each(tables) do |table|
+        ::Parallel.each(tables.sort_by{|t| t.source_table.count}.reverse) do |table|
           begin
             table.progress_bar_class DataAnon::Utils::ParallelProgressBar
             table.process


### PR DESCRIPTION
When using `execution_strategy DataAnon::Parallel::Table`, the tables will be processed in the order they are defined. If the number of tables is larger than the number of processes, then some tables have to wait for others to be completed.

We should try to make the table that takes longest to finish processing start processing first. This will make the entire run complete more quickly. In general, more rows = more time to process. So run the biggest tables first.