### PR TITLE
Fix deprecation warnings in specs

### DIFF
--- a/spec/acceptance/mongodb_whitelist_spec.rb
+++ b/spec/acceptance/mongodb_whitelist_spec.rb
@@ -95,7 +95,7 @@ describe 'End 2 End MongoDB Whitelist Acceptance Test' do
     feature1 = plan['features'][0]
     [10737418240, 21474836480, 53687091200].should include(feature1['max_storage'])
     feature1['type'].should == 'AmazonS3'
-    feature1['users']['max'].should be_kind_of(Fixnum)
+    feature1['users']['max'].should be_kind_of(Integer)
     [true,false].should include(feature1['users']['additional'])
 
 

--- a/spec/strategy/field/default_anon_spec.rb
+++ b/spec/strategy/field/default_anon_spec.rb
@@ -29,14 +29,14 @@ describe FieldStrategy::DefaultAnon do
     let(:field) {DataAnon::Core::Field.new('int_field',2,1,nil)}
     let(:anonymized_value) {DefaultAnon.new.anonymize(field)}
 
-    it { anonymized_value.should be_kind_of Fixnum  }
+    it { anonymized_value.should be_kind_of Integer  }
   end
 
   describe 'anonymized bignum value' do
     let(:field) {DataAnon::Core::Field.new('int_field',2348723489723847382947,1,nil)}
     let(:anonymized_value) {DefaultAnon.new.anonymize(field)}
 
-    it { anonymized_value.should be_kind_of Bignum  }
+    it { anonymized_value.should be_kind_of Integer  }
   end
 
   describe 'anonymized string value' do


### PR DESCRIPTION
As of Ruby 2.4 `Bignum` and `Fixnum` are deprecated, use `Integer` instead.