### PR TITLE
RandomInt border issue

### DIFF
--- a/lib/strategy/field/datetime/anonymize_time.rb
+++ b/lib/strategy/field/datetime/anonymize_time.rb
@@ -58,8 +58,8 @@ module DataAnon
           month = @anonymize_month? DataAnon::Utils::RandomInt.generate(1,12) : original_time.month
           days_in_month = Time.new(year,month,1,1,1,1).end_of_month.day
           day = @anonymize_day? DataAnon::Utils::RandomInt.generate(1,days_in_month) : original_time.day
-          hour = @anonymize_hour? DataAnon::Utils::RandomInt.generate(1,24) : original_time.hour
-          min = @anonymize_min? DataAnon::Utils::RandomInt.generate(1,60) : original_time.min
+          hour = @anonymize_hour? DataAnon::Utils::RandomInt.generate(0,23) : original_time.hour
+          min = @anonymize_min? DataAnon::Utils::RandomInt.generate(0,59) : original_time.min
           sec = original_time.sec
 
           create_object(year, month, day, hour, min, sec)

--- a/lib/utils/random_int.rb
+++ b/lib/utils/random_int.rb
@@ -4,7 +4,7 @@ module DataAnon
 
       def self.generate min, max
         return 0 if (min == 0 && max == 0)
-        Random.new.rand min...max
+        Random.new.rand min..max
       end
     end
   end


### PR DESCRIPTION
Replacing _Random.new.rand min...max_ by _Random.new.rand min..max_.

RandomInt was generating a number between min and (max-1), this border issue caused RandomIntegerDelta class to be unbalanced. The distribution generated was not centred, because it was sampling numbers between [- Delta, Delta-1].
 
AnonymizeTime class was also impacted by this border issue.

