### PR TITLE
Upgrade activerecord and activesupport to ~> 6.0

### DIFF
--- a/data-anonymization.gemspec
+++ b/data-anonymization.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency('activerecord', '~> 5.2')
-  gem.add_dependency('composite_primary_keys', '~> 11.0')
-  gem.add_dependency('activesupport', '~> 5.2')
+  gem.add_dependency('activerecord', '~> 6.0')
+  gem.add_dependency('composite_primary_keys', '~> 12.0')
+  gem.add_dependency('activesupport', '~> 6.0')
   gem.add_dependency('rgeo', '~> 1.0')
   gem.add_dependency('rgeo-geojson', '~> 2.0')
   gem.add_dependency('powerbar', '~> 1.0')


### PR DESCRIPTION
To allow the gem to work with Rails 6 apps.