### PR TITLE
Fix clashing class variable names

### DIFF
--- a/lib/utils/logging.rb
+++ b/lib/utils/logging.rb
@@ -6,13 +6,13 @@ module DataAnon
     module Logging
 
       def logger
-        @@logger ||= (self.logger = Logger.new(STDOUT) )
+        @@utils_logger ||= (self.logger = Logger.new(STDOUT) )
       end
 
       def logger= logger
-        @@logger = logger
+        @@utils_logger = logger
         ActiveRecord::Base.logger = logger
-        @@logger
+        @@utils_logger
       end
 
     end


### PR DESCRIPTION
Before, after upgrading to Ruby 3.1, we saw `DataAnon::Utils::Logging`'s class variable clashed. Projects using the gem would complain that it was overtaking `@@logger`. We fixed the clashing variable name by renaming it to `@@utils_logger`.

Closes #79 