### PR TITLE
Upgrade activerecord and activesupport to ~> 7.1

### DIFF
--- a/data-anonymization.gemspec
+++ b/data-anonymization.gemspec
@@ -19,9 +19,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency('activerecord', '~> 7.0')
-  gem.add_dependency('activesupport', '~> 7.0')
-  gem.add_dependency('composite_primary_keys', '~> 14.0')
+  gem.add_dependency('activerecord', '~> 7.1')
+  gem.add_dependency('activesupport', '~> 7.1')
   gem.add_dependency('parallel', '~> 1.21')
   gem.add_dependency('powerbar', '~> 2.0')
   gem.add_dependency('rgeo', '~> 2.4.0')

--- a/lib/strategy/base.rb
+++ b/lib/strategy/base.rb
@@ -95,6 +95,7 @@ module DataAnon
       def process
         logger.debug "Processing table #{@name} with fields strategies #{@fields}"
         total = source_table.count
+
         if total > 0
           progress = progress_bar.new(@name, total)
           if @primary_keys.empty? || !@batch_size.present?
@@ -106,8 +107,8 @@ module DataAnon
           end
           progress.close
         end
-        if source_table.respond_to?('clear_all_connections!')
-          source_table.clear_all_connections!
+        if source_table.respond_to?("connection_handler")
+          source_table.connection_handler.clear_all_connections!
         end
       end
 

--- a/lib/utils/database.rb
+++ b/lib/utils/database.rb
@@ -1,5 +1,4 @@
 require 'active_record'
-require 'composite_primary_keys'
 require 'logger'
 
 module DataAnon
@@ -28,7 +27,7 @@ module DataAnon
         return database.const_get(klass_name, false) if database.const_defined?(klass_name, false)
         database.const_set(klass_name, Class.new(database) do
             self.table_name = table_name
-            self.primary_keys = primary_keys if primary_keys.length > 1
+            self.primary_key = primary_keys if primary_keys.length > 1
             self.primary_key = primary_keys[0] if primary_keys.length == 1
             self.primary_key = nil if primary_keys.length == 0
             self.inheritance_column = :_type_disabled


### PR DESCRIPTION
This includes removing composite_primary_keys gems as a dependency. ActiveRecord 7.1 now has built-in support for composite primary keys.

The only change this required was calling ActiveRecord's `primary_key` class method instead of composite_primary_keys's `primary_keys` method.